### PR TITLE
Relocate Claude MCP server to project root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@paybyrd/ai-agent-toolkit",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@paybyrd/ai-agent-toolkit",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.7.0",
@@ -19,7 +19,7 @@
         "zod-to-json-schema": "^3.22.4"
       },
       "bin": {
-        "claude-mcp-server": "dist/claude/servers/index.js"
+        "ai-agent-toolkit": "dist/index.js"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/package.json
+++ b/package.json
@@ -9,16 +9,14 @@
   "homepage": "https://github.com/paybyrd/ai-agent-toolkit-js#readme",
   "bugs": "https://github.com/paybyrd/ai-agent-toolkit-js/issues",  
   "scripts": {
-    "build": "tsc && node -e \"require('fs').chmodSync('dist/claude/servers/index.js', '755')\"",
+    "build": "tsc",
     "clean": "rm -rf dist",
     "lint": "eslint \"./**/*.ts*\"",
     "prettier": "prettier './**/*.{js,ts,md,html,css}' --write",
     "prettier-check": "prettier './**/*.{js,ts,md,html,css}' --check",
     "test": "jest"    
   },
-  "bin": {
-    "claude-mcp-server": "./dist/claude/servers/index.js"
-  },
+  "bin": "dist/index.js",
   "keywords": [
     "agentkit",
     "ai",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { PaybyrdAgentToolkit } from '../index.js';
+import { PaybyrdAgentToolkit } from './claude/index.js';
 import colors from 'colors';
 
 function initializeToolkit() {
  
   const apiKey = process.env.PAYBYRD_API_KEY;
   if (!apiKey || apiKey.trim() === "") {
-    const errorMsg = "A valid 'PAYBYRD_API_KEY' is required!";    
+    const errorMsg = "A valid 'PAYBYRD_API_KEY' is required!"; 
+    console.error(errorMsg);   
     throw new Error(errorMsg);
   }
 


### PR DESCRIPTION
- Moved the server execution file from src/claude/servers/index.ts to src/index.ts
- Updated bin in package.json to point to the new executable path
- Simplified build script by removing chmod command
- Added error logging to console

🤖 Generated with [Claude Code](https://claude.ai/code)